### PR TITLE
🔧 useGetSchedule hook 수정

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -3,7 +3,7 @@ import { getCookie } from '../utils/cookies';
 
 const getAxiosInstance = (option?: { multi?: boolean }) => {
   const config: AxiosRequestConfig = {
-    baseURL: import.meta.env.VITE_API_URL,
+    baseURL: '/',
     headers: {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*'

--- a/src/components/ApplicationPage/ApplyCalendar/index.tsx
+++ b/src/components/ApplicationPage/ApplyCalendar/index.tsx
@@ -6,6 +6,7 @@ import useGetSchedule from '../../../hooks/useGetSchedule';
 import * as S from '../../common/ScheduleCalendar/styles';
 import { useEffect, useState } from 'react';
 import CalendarGuide from '../../common/CalendarGuide';
+import { EventContentArg } from '@fullcalendar/core/index.js';
 
 function ApplyCalendar({ select, handleDateSelect }: ICalendarProps) {
   const { data, isLoading, error } = useGetSchedule(select);
@@ -19,7 +20,17 @@ function ApplyCalendar({ select, handleDateSelect }: ICalendarProps) {
 
   // selectable 값을 선택에 따라 동적으로 변경
   const selectable = select === 'annual' ? true : false;
+  // 캘린더 이벤트 바 스타일
+  function renderEventContent(eventInfo: EventContentArg) {
+    const { status } = eventInfo.event.extendedProps;
 
+    return (
+      <>
+        {status === 'wait' && <strong>승인대기</strong>}
+        <i>{eventInfo.event.title}</i>
+      </>
+    );
+  }
   // 이전에 선택한 값
   // dateClick 이벤트 처리 함수
   const handleDateClick = (info: DateClickArg) => {
@@ -47,6 +58,7 @@ function ApplyCalendar({ select, handleDateSelect }: ICalendarProps) {
         selectable={selectable}
         select={(info) => handleDateSelect(info)}
         dateClick={handleDateClick}
+        eventContent={renderEventContent}
       />
     </S.StyleWrapper>
   );

--- a/src/components/ApplicationPage/ApplyCalendar/index.tsx
+++ b/src/components/ApplicationPage/ApplyCalendar/index.tsx
@@ -2,11 +2,11 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { DateClickArg } from '@fullcalendar/interaction';
 import { ICalendarProps } from '../../../interfaces/applicationPage';
-import useGetSchedule from '../../../hooks/useGetSchedule';
 import * as S from '../../common/ScheduleCalendar/styles';
 import { useEffect, useState } from 'react';
 import CalendarGuide from '../../common/CalendarGuide';
 import { EventContentArg } from '@fullcalendar/core/index.js';
+import useGetSchedule from '../../../hooks/useGetSchedule';
 
 function ApplyCalendar({ select, handleDateSelect }: ICalendarProps) {
   const { data, isLoading, error } = useGetSchedule(select);

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -2,21 +2,23 @@ import { useQuery } from 'react-query';
 import { getSchedules } from '../apis/auth';
 import { IUseScheduleQuery } from '../interfaces/common';
 import { AxiosError } from 'axios';
+import { useLocation } from 'react-router-dom';
 
 function useGetSchedule(select?: 'annual' | 'duty') {
   const { data, isLoading, error } = useQuery<IUseScheduleQuery, AxiosError>('schedule', getSchedules);
   const userId = 1; // store에서 가져오기
+  const { pathname } = useLocation();
   if (!data?.data) return { data: [], isLoading, error };
 
   const schedules = data['data'];
   // annual -> 모든 사람 연차 + 내 당직
   // duty -> 내 연차 + 내 당직
   const annualList = schedules.filter((item) => {
-    if (select === 'duty') return item.type === 'annual' && item.id === userId;
+    if (select === 'duty' || pathname === '/viewSchedule') return item.type === 'annual' && item.id === userId;
     return item.type === 'annual';
   });
   const dutyList = schedules.filter((item) => {
-    if (select) return item.type === 'duty' && item.id === userId;
+    if (select || pathname === '/viewSchedule') return item.type === 'duty' && item.id === userId;
     return item.type === 'duty';
   });
 

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -19,6 +19,7 @@ function useGetSchedule(select?: 'annual' | 'duty') {
         title: username,
         start: new Date(start_date),
         end: new Date(end_date),
+        allDay: true,
         extendedProps: { status }
       };
     });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
-// import { worker } from './mocks/broswer';
+import { worker } from './mocks/broswer';
 
-// if (process.env.NODE_ENV === 'development') {
-//   worker.start();
-// }
+if (process.env.NODE_ENV === 'development') {
+  worker.start();
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/mocks/api/data/db.ts
+++ b/src/mocks/api/data/db.ts
@@ -108,10 +108,38 @@ export const db = {
     },
     {
       username: '신사원',
-      type: 'annual',
+      type: 'duty',
       status: 'approve',
-      start_date: '2023-05-10',
-      end_date: '2023-05-11'
+      start_date: '2023-06-10',
+      end_date: '2023-06-10'
+    },
+    {
+      username: '황사원',
+      type: 'annual',
+      status: 'wait',
+      start_date: '2023-06-10',
+      end_date: '2023-06-12'
+    },
+    {
+      username: '진사원',
+      type: 'duty',
+      status: 'approve',
+      start_date: '2023-05-21',
+      end_date: '2023-05-21'
+    },
+    {
+      username: '유사원',
+      type: 'annual',
+      status: 'wait',
+      start_date: '2023-05-24',
+      end_date: '2023-05-24'
+    },
+    {
+      username: '구사원',
+      type: 'annual',
+      status: 'wait',
+      start_date: '2023-05-21',
+      end_date: '2023-05-21'
     }
   ]
 };

--- a/src/mocks/api/data/db.ts
+++ b/src/mocks/api/data/db.ts
@@ -36,110 +36,20 @@ export const db = {
     { id: 6, status: 'approved', type: 'annual', start_date: '2021-04-27', end_date: '2021-04-27', user_id: 4 }
   ],
   schedules: [
-    {
-      username: '김사원',
-      type: 'annual',
-      status: 'approve',
-      start_date: '2023-05-05',
-      end_date: '2023-05-07'
-    },
-    {
-      username: '김사원',
-      type: 'annual',
-      status: 'wait',
-      start_date: '2023-05-27',
-      end_date: '2023-05-28'
-    },
-    {
-      username: '김사원',
-      type: 'duty',
-      status: 'approve',
-      start_date: '2023-05-27',
-      end_date: '2023-05-27'
-    },
-    {
-      username: '김사원',
-      type: 'duty',
-      status: 'wait',
-      start_date: '2023-05-10',
-      end_date: '2023-05-10'
-    },
-    {
-      username: '박사원',
-      type: 'duty',
-      status: 'approve',
-      start_date: '2023-05-21',
-      end_date: '2023-05-21'
-    },
-    {
-      username: '나사원',
-      type: 'duty',
-      status: 'wait',
-      start_date: '2023-05-10',
-      end_date: '2023-05-10'
-    },
-    {
-      username: '이사원',
-      type: 'annual',
-      status: 'approve',
-      start_date: '2023-05-05',
-      end_date: '2023-05-07'
-    },
-    {
-      username: '박사원',
-      type: 'annual',
-      status: 'approve',
-      start_date: '2023-05-17',
-      end_date: '2023-05-18'
-    },
-    {
-      username: '정사원',
-      type: 'annual',
-      status: 'wait',
-      start_date: '2023-05-14',
-      end_date: '2023-05-15'
-    },
-    {
-      username: '최사원',
-      type: 'annual',
-      status: 'wait',
-      start_date: '2023-05-09',
-      end_date: '2023-05-10'
-    },
-    {
-      username: '신사원',
-      type: 'duty',
-      status: 'approve',
-      start_date: '2023-06-10',
-      end_date: '2023-06-10'
-    },
-    {
-      username: '황사원',
-      type: 'annual',
-      status: 'wait',
-      start_date: '2023-06-10',
-      end_date: '2023-06-12'
-    },
-    {
-      username: '진사원',
-      type: 'duty',
-      status: 'approve',
-      start_date: '2023-05-21',
-      end_date: '2023-05-21'
-    },
-    {
-      username: '유사원',
-      type: 'annual',
-      status: 'wait',
-      start_date: '2023-05-24',
-      end_date: '2023-05-24'
-    },
-    {
-      username: '구사원',
-      type: 'annual',
-      status: 'wait',
-      start_date: '2023-05-21',
-      end_date: '2023-05-21'
-    }
+    { id: 1, username: '김사원', type: 'annual', status: 'approve', start_date: '2023-05-05', end_date: '2023-05-07' },
+    { id: 1, username: '김사원', type: 'annual', status: 'wait', start_date: '2023-05-27', end_date: '2023-05-28' },
+    { id: 1, username: '김사원', type: 'duty', status: 'approve', start_date: '2023-05-27', end_date: '2023-05-27' },
+    { id: 1, username: '김사원', type: 'duty', status: 'wait', start_date: '2023-05-10', end_date: '2023-05-10' },
+    { id: 2, username: '박사원', type: 'duty', status: 'approve', start_date: '2023-05-21', end_date: '2023-05-21' },
+    { id: 3, username: '나사원', type: 'duty', status: 'wait', start_date: '2023-05-10', end_date: '2023-05-10' },
+    { id: 4, username: '이사원', type: 'annual', status: 'approve', start_date: '2023-05-05', end_date: '2023-05-07' },
+    { id: 2, username: '박사원', type: 'annual', status: 'approve', start_date: '2023-05-17', end_date: '2023-05-18' },
+    { id: 5, username: '정사원', type: 'annual', status: 'wait', start_date: '2023-05-14', end_date: '2023-05-15' },
+    { id: 6, username: '최사원', type: 'annual', status: 'wait', start_date: '2023-05-09', end_date: '2023-05-10' },
+    { id: 7, username: '신사원', type: 'duty', status: 'approve', start_date: '2023-06-10', end_date: '2023-06-10' },
+    { id: 8, username: '황사원', type: 'annual', status: 'wait', start_date: '2023-06-10', end_date: '2023-06-12' },
+    { id: 9, username: '진사원', type: 'duty', status: 'approve', start_date: '2023-05-21', end_date: '2023-05-21' },
+    { id: 10, username: '유사원', type: 'annual', status: 'wait', start_date: '2023-05-24', end_date: '2023-05-24' },
+    { id: 11, username: '구사원', type: 'annual', status: 'wait', start_date: '2023-05-21', end_date: '2023-05-21' }
   ]
 };


### PR DESCRIPTION
- 연차 신청 페이지에서 연차 신청 캘린더는 모든 사람 연차 + 내 당직, 당직 신청 캘린더는 내 연차 + 내 당직만 보이도록
- 홈 화면에서 모든 연차 + 모든 당직 제대로 출력되지 않는 오류 수정
- useLocation 추가하여 내 일정 보기 캘린더에서는 내 연차 + 내 당직만 보여지도록 세팅

[참고사항]
- 아직 store가 구현되지 않아 임시적으로 userId = 1 인 유저의 데이터만 들고오도록 세팅했습니다. 추후 수정할 예정입니다.
- 아직 useGetSchedule 훅에 날짜 매개변수 추가하지 않았습니다. api에 맞게 다시 수정할 예정입니다. 일단은 msw 기준으로 봐주세요!