### PR TITLE
✨ store 관련 설정 및 api 연결에 따른 수정 작업

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "redux-logger": "^3.0.6",
     "styled-components": "^5.3.10",
     "styled-normalize": "^8.0.7",
-    "styled-reset": "^4.4.6"
+    "styled-reset": "^4.4.6",
+    "sweetalert2": "^11.7.5",
+    "sweetalert2-react-content": "^5.0.7"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,6 +1,6 @@
 import { axiosInstance } from './instance';
 
-export const getSchedules = async () => {
-  const response = await axiosInstance().get('/auth/leave');
+export const getSchedules = async (date: string) => {
+  const response = await axiosInstance().get(`/auth/leave/month/${date}`);
   return response.data;
 };

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -3,10 +3,11 @@ import { getCookie } from '../utils/cookies';
 
 const getAxiosInstance = (option?: { multi?: boolean }) => {
   const config: AxiosRequestConfig = {
-    baseURL: '/',
+    baseURL: import.meta.env.VITE_API_URL,
     headers: {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*'
+      'Access-Control-Allow-Origin': '*',
+      Authorization: `Bearer ${import.meta.env.VITE_ACCESS_TOKEN}`
     },
     withCredentials: true
   };

--- a/src/components/ApplicationPage/Application/index.tsx
+++ b/src/components/ApplicationPage/Application/index.tsx
@@ -6,46 +6,46 @@ import { DateClickArg } from '@fullcalendar/interaction/index.js';
 import ApplyInfo from '../ApplyInfo';
 
 function Application() {
-  const [select, setSelect] = useState<'annual' | 'duty'>('annual');
-  const [date, setDate] = useState({ start_date: '', end_date: '' });
+  const [select, setSelect] = useState<'ANNUAL' | 'DUTY'>('ANNUAL');
+  const [date, setDate] = useState({ startDate: '', endDate: '' });
 
   const resetDate = () => {
-    setDate({ start_date: '', end_date: '' });
+    setDate({ startDate: '', endDate: '' });
   };
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLButtonElement;
-    const select = target.dataset.select as 'annual' | 'duty';
+    const select = target.dataset.select as 'ANNUAL' | 'DUTY';
     if (select) {
       setSelect(select);
       resetDate();
     }
   };
   const handleDateSelect = (date: DateSelectArg | DateClickArg) => {
-    if (select === 'duty') {
+    if (select === 'DUTY') {
       const { dateStr } = date as DateClickArg;
-      setDate({ start_date: dateStr, end_date: dateStr });
+      setDate({ startDate: dateStr, endDate: dateStr });
       return;
     }
     const { startStr, endStr } = date as DateSelectArg;
     setDate({
-      start_date: startStr,
+      startDate: startStr,
       // fullCalendar에서 endStr은 선택한 날짜의 다음날을 가리킴 -> 해당 오류 수정
-      end_date: new Date(new Date(endStr).getTime() - 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+      endDate: new Date(new Date(endStr).getTime() - 24 * 60 * 60 * 1000).toISOString().split('T')[0]
     });
   };
 
   return (
     <S.Wrapper>
       <S.SelectBtns onClick={handleClick}>
-        <S.SelectBtn data-select='annual' className={select === 'annual' ? 'active' : ''}>
+        <S.SelectBtn data-select='ANNUAL' className={select === 'ANNUAL' ? 'active' : ''}>
           연차 신청
         </S.SelectBtn>
-        <S.SelectBtn data-select='duty' className={select === 'duty' ? 'active' : ''}>
+        <S.SelectBtn data-select='DUTY' className={select === 'DUTY' ? 'active' : ''}>
           당직 신청
         </S.SelectBtn>
       </S.SelectBtns>
       <ApplyCalendar select={select} applyDateSelect={handleDateSelect} resetDate={resetDate} />
-      {date.start_date && date.end_date && <ApplyInfo select={select} date={date} />}
+      {date.startDate && date.endDate && <ApplyInfo select={select} date={date} />}
     </S.Wrapper>
   );
 }

--- a/src/components/ApplicationPage/Application/index.tsx
+++ b/src/components/ApplicationPage/Application/index.tsx
@@ -9,12 +9,15 @@ function Application() {
   const [select, setSelect] = useState<'annual' | 'duty'>('annual');
   const [date, setDate] = useState({ start_date: '', end_date: '' });
 
+  const resetDate = () => {
+    setDate({ start_date: '', end_date: '' });
+  };
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     const target = e.target as HTMLButtonElement;
     const select = target.dataset.select as 'annual' | 'duty';
     if (select) {
       setSelect(select);
-      setDate({ start_date: '', end_date: '' });
+      resetDate();
     }
   };
   const handleDateSelect = (date: DateSelectArg | DateClickArg) => {
@@ -41,7 +44,7 @@ function Application() {
           당직 신청
         </S.SelectBtn>
       </S.SelectBtns>
-      <ApplyCalendar select={select} handleDateSelect={handleDateSelect} />
+      <ApplyCalendar select={select} applyDateSelect={handleDateSelect} resetDate={resetDate} />
       {date.start_date && date.end_date && <ApplyInfo select={select} date={date} />}
     </S.Wrapper>
   );

--- a/src/components/ApplicationPage/ApplyCalendar/index.tsx
+++ b/src/components/ApplicationPage/ApplyCalendar/index.tsx
@@ -9,26 +9,26 @@ import { DateSelectArg, EventContentArg } from '@fullcalendar/core/index.js';
 import useGetSchedule from '../../../hooks/useGetSchedule';
 
 function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
-  const { data, isLoading, error } = useGetSchedule(select);
+  const today = new Date().toISOString().split('T')[0];
+  const [nowMonth, setNowMonth] = useState(today.slice(0, 7));
+  const { data, isLoading, error } = useGetSchedule(nowMonth, select);
   const [prevClickedDate, setPrevClickedDate] = useState<null | HTMLElement>(null);
   const calendarRef = useRef<FullCalendar>(null);
-  const today = new Date().toISOString().split('T')[0];
-
   useEffect(() => {
     if (prevClickedDate !== null) {
       prevClickedDate.style.backgroundColor = '';
     }
   }, [select]);
-
+  console.log(data);
   // selectable 값을 선택에 따라 동적으로 변경
-  const selectable = select === 'annual' ? true : false;
+  const selectable = select === 'ANNUAL' ? true : false;
   // 캘린더 이벤트 바 스타일
   function renderEventContent(eventInfo: EventContentArg) {
     const { status } = eventInfo.event.extendedProps;
 
     return (
       <>
-        {status === 'wait' && <strong>승인대기</strong>}
+        {status === 'WAITING' && <strong>승인대기</strong>}
         <i>{eventInfo.event.title}</i>
       </>
     );
@@ -44,7 +44,7 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
   // 이전에 선택한 값
   // dateClick 이벤트 처리 함수
   const handleDateClick = (info: DateClickArg) => {
-    if (select === 'annual') return;
+    if (select === 'ANNUAL') return;
 
     if (info.dateStr < today) {
       calendarRef.current?.getApi().unselect();

--- a/src/components/ApplicationPage/ApplyCalendar/index.tsx
+++ b/src/components/ApplicationPage/ApplyCalendar/index.tsx
@@ -21,6 +21,14 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
     }
   }, [select]);
 
+  useEffect(() => {
+    const { current } = calendarRef;
+    if (current) {
+      console.log(new Date(nowMonth));
+      current.getApi().gotoDate(new Date(nowMonth));
+    }
+  }, [nowMonth]);
+
   // selectable 값을 선택에 따라 동적으로 변경
   const selectable = select === 'ANNUAL' ? true : false;
   // 캘린더 이벤트 바 스타일
@@ -65,6 +73,18 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
     setPrevClickedDate(clickedDateElement);
     applyDateSelect(info);
   };
+  // 이전/다음 버튼 클릭 이벤트 함수
+  const handlePrevButtonClick = () => {
+    const prevMonth = new Date(nowMonth);
+    prevMonth.setMonth(prevMonth.getMonth() - 1);
+    setNowMonth(prevMonth.toISOString().slice(0, 7));
+  };
+
+  const handleNextButtonClick = () => {
+    const nextMonth = new Date(nowMonth);
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    setNowMonth(nextMonth.toISOString().slice(0, 7));
+  };
 
   if (isLoading) return <div>loading...</div>;
   return (
@@ -80,18 +100,10 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
         eventContent={renderEventContent}
         customButtons={{
           prev: {
-            click: () => {
-              const prevMonth = new Date(nowMonth);
-              prevMonth.setMonth(prevMonth.getMonth() - 1);
-              setNowMonth(prevMonth.toISOString().slice(0, 7));
-            }
+            click: handlePrevButtonClick
           },
           next: {
-            click: () => {
-              const prevMonth = new Date(nowMonth);
-              prevMonth.setMonth(prevMonth.getMonth() + 1);
-              setNowMonth(prevMonth.toISOString().slice(0, 7));
-            }
+            click: handleNextButtonClick
           }
         }}
       />

--- a/src/components/ApplicationPage/ApplyCalendar/index.tsx
+++ b/src/components/ApplicationPage/ApplyCalendar/index.tsx
@@ -14,12 +14,13 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
   const { data, isLoading, error } = useGetSchedule(nowMonth, select);
   const [prevClickedDate, setPrevClickedDate] = useState<null | HTMLElement>(null);
   const calendarRef = useRef<FullCalendar>(null);
+
   useEffect(() => {
     if (prevClickedDate !== null) {
       prevClickedDate.style.backgroundColor = '';
     }
   }, [select]);
-  console.log(data);
+
   // selectable 값을 선택에 따라 동적으로 변경
   const selectable = select === 'ANNUAL' ? true : false;
   // 캘린더 이벤트 바 스타일
@@ -41,6 +42,7 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
     }
     applyDateSelect(date);
   };
+
   // 이전에 선택한 값
   // dateClick 이벤트 처리 함수
   const handleDateClick = (info: DateClickArg) => {
@@ -76,6 +78,22 @@ function ApplyCalendar({ select, applyDateSelect, resetDate }: ICalendarProps) {
         select={handleDateSelect}
         dateClick={handleDateClick}
         eventContent={renderEventContent}
+        customButtons={{
+          prev: {
+            click: () => {
+              const prevMonth = new Date(nowMonth);
+              prevMonth.setMonth(prevMonth.getMonth() - 1);
+              setNowMonth(prevMonth.toISOString().slice(0, 7));
+            }
+          },
+          next: {
+            click: () => {
+              const prevMonth = new Date(nowMonth);
+              prevMonth.setMonth(prevMonth.getMonth() + 1);
+              setNowMonth(prevMonth.toISOString().slice(0, 7));
+            }
+          }
+        }}
       />
     </S.StyleWrapper>
   );

--- a/src/components/ApplicationPage/ApplyInfo/index.tsx
+++ b/src/components/ApplicationPage/ApplyInfo/index.tsx
@@ -2,11 +2,11 @@ import { IApplyInfoProps } from '../../../interfaces/applicationPage';
 import * as S from './styles';
 
 function ApplyInfo({ select, date }: IApplyInfoProps) {
-  const selectText = select === 'annual' ? '연차' : '당직';
+  const selectText = select === 'ANNUAL' ? '연차' : '당직';
   const selectDays = (() => {
-    if (!date.start_date || !date.end_date) return 0;
-    const startDate = new Date(date.start_date);
-    const endDate = new Date(date.end_date);
+    if (!date.startDate || !date.endDate) return 0;
+    const startDate = new Date(date.startDate);
+    const endDate = new Date(date.endDate);
     const oneDay = 1000 * 60 * 60 * 24; // milliseconds in a day
     const diffTime = Math.abs(endDate.getTime() - startDate.getTime());
     const diffDays = Math.ceil(diffTime / oneDay);
@@ -16,7 +16,7 @@ function ApplyInfo({ select, date }: IApplyInfoProps) {
     <S.ApplyInfo>
       <S.ApplyInfoTitle>{selectText} 신청 정보</S.ApplyInfoTitle>
       <S.ApplyInfoContent>
-        신청 날짜 : {date.start_date} {select === 'annual' ? '~ ' + date.end_date : ''}
+        신청 날짜 : {date.startDate} {select === 'ANNUAL' ? '~ ' + date.endDate : ''}
       </S.ApplyInfoContent>
       <S.ApplyInfoContent>신청 일수 : {selectDays}일</S.ApplyInfoContent>
       <S.ApplyBtn>신청하기</S.ApplyBtn>

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -3,26 +3,28 @@ import { getSchedules } from '../apis/auth';
 import { IUseScheduleQuery } from '../interfaces/common';
 import { AxiosError } from 'axios';
 import { useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 function useGetSchedule(nowMonth: string, select?: 'ANNUAL' | 'DUTY') {
   const { data, isLoading, error } = useQuery<IUseScheduleQuery, AxiosError>(['schedules', nowMonth], () => {
     return getSchedules(nowMonth);
   });
+  const { id } = useSelector((state: any) => state.loginedUser);
+
   const { pathname } = useLocation();
 
   if (isLoading || !data?.data) return { data: [], isLoading, error };
 
-  const userId = 1; // store에서 가져오기
   const schedules = data.data;
   // ANNUAL -> 모든 사람 연차 + 내 당직
   // DUTY -> 내 연차 + 내 당직
   const annualList = schedules.filter((item) => {
-    if (select === 'DUTY' || pathname === '/viewSchedule') return item.type === 'ANNUAL' && item.id === userId;
+    if (select === 'DUTY' || pathname === '/viewSchedule') return item.type === 'ANNUAL' && item.id === id;
     return item.type === 'ANNUAL';
   });
   const dutyList = schedules.filter((item) => {
     // select가 무엇이 되었든간에 내 당직 정보만 보여줘야 함
-    if (select || pathname === '/viewSchedule') return item.type === 'DUTY' && item.id === userId;
+    if (select || pathname === '/viewSchedule') return item.type === 'DUTY' && item.id === id;
     return item.type === 'DUTY';
   });
 

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -18,6 +18,7 @@ function useGetSchedule(select?: 'annual' | 'duty') {
     return item.type === 'annual';
   });
   const dutyList = schedules.filter((item) => {
+    // select가 무엇이 되었든간에 내 당직 정보만 보여줘야 함
     if (select || pathname === '/viewSchedule') return item.type === 'duty' && item.id === userId;
     return item.type === 'duty';
   });

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -4,45 +4,48 @@ import { IUseScheduleQuery } from '../interfaces/common';
 import { AxiosError } from 'axios';
 import { useLocation } from 'react-router-dom';
 
-function useGetSchedule(select?: 'annual' | 'duty') {
-  const { data, isLoading, error } = useQuery<IUseScheduleQuery, AxiosError>('schedule', getSchedules);
-  const userId = 1; // store에서 가져오기
+function useGetSchedule(nowMonth: string, select?: 'ANNUAL' | 'DUTY') {
+  const { data, isLoading, error } = useQuery<IUseScheduleQuery, AxiosError>(['schedules', nowMonth], () => {
+    return getSchedules(nowMonth);
+  });
   const { pathname } = useLocation();
-  if (!data?.data) return { data: [], isLoading, error };
 
-  const schedules = data['data'];
-  // annual -> 모든 사람 연차 + 내 당직
-  // duty -> 내 연차 + 내 당직
+  if (isLoading || !data?.data) return { data: [], isLoading, error };
+
+  const userId = 1; // store에서 가져오기
+  const schedules = data.data;
+  // ANNUAL -> 모든 사람 연차 + 내 당직
+  // DUTY -> 내 연차 + 내 당직
   const annualList = schedules.filter((item) => {
-    if (select === 'duty' || pathname === '/viewSchedule') return item.type === 'annual' && item.id === userId;
-    return item.type === 'annual';
+    if (select === 'DUTY' || pathname === '/viewSchedule') return item.type === 'ANNUAL' && item.id === userId;
+    return item.type === 'ANNUAL';
   });
   const dutyList = schedules.filter((item) => {
     // select가 무엇이 되었든간에 내 당직 정보만 보여줘야 함
-    if (select || pathname === '/viewSchedule') return item.type === 'duty' && item.id === userId;
-    return item.type === 'duty';
+    if (select || pathname === '/viewSchedule') return item.type === 'DUTY' && item.id === userId;
+    return item.type === 'DUTY';
   });
 
   const scheduleData = () => {
     const annualResult = annualList.map((item, index) => {
-      const { username, start_date, end_date, status } = item;
+      const { username, startDate, endDate, status } = item;
       return {
         id: `annual-${index}`,
         title: username,
-        start: new Date(start_date),
-        end: new Date(end_date),
+        start: new Date(startDate),
+        end: new Date(endDate),
         allDay: true,
         extendedProps: { status }
       };
     });
 
     const dutyResult = dutyList.map((item, index) => {
-      const { username, start_date, end_date, status } = item;
+      const { username, startDate, endDate, status } = item;
       return {
         id: `duty-${index}`,
         title: username,
-        start: new Date(start_date),
-        end: new Date(end_date),
+        start: new Date(startDate),
+        end: new Date(endDate),
         color: '#ba55d3',
         allDay: true,
         extendedProps: { status }

--- a/src/interfaces/applicationPage.ts
+++ b/src/interfaces/applicationPage.ts
@@ -13,12 +13,12 @@ export interface ICalendarInfo {
 }
 
 export interface ICalendarProps {
-  select: 'annual' | 'duty';
+  select: 'ANNUAL' | 'DUTY';
   applyDateSelect: (date: DateSelectArg | DateClickArg) => void;
   resetDate: () => void;
 }
 
 export interface IApplyInfoProps {
-  select: 'annual' | 'duty';
-  date: { start_date: string; end_date: string };
+  select: 'ANNUAL' | 'DUTY';
+  date: { startDate: string; endDate: string };
 }

--- a/src/interfaces/applicationPage.ts
+++ b/src/interfaces/applicationPage.ts
@@ -14,7 +14,8 @@ export interface ICalendarInfo {
 
 export interface ICalendarProps {
   select: 'annual' | 'duty';
-  handleDateSelect: (date: DateSelectArg | DateClickArg) => void;
+  applyDateSelect: (date: DateSelectArg | DateClickArg) => void;
+  resetDate: () => void;
 }
 
 export interface IApplyInfoProps {

--- a/src/interfaces/common.ts
+++ b/src/interfaces/common.ts
@@ -3,11 +3,11 @@ export interface pageTitleProps {
 }
 
 export interface ISchedule {
-  id: number;
-  status: 'waiting' | 'approved' | 'rejected';
-  type: 'duty' | 'annual';
-  start_date: string;
-  end_date: string;
+  userId: number;
+  status: 'WAITING' | 'APPROVED' | 'REJECTED';
+  type: 'DUTY' | 'ANNUAL';
+  startDate: string;
+  endDate: string;
   username: string;
 }
 

--- a/src/interfaces/store.ts
+++ b/src/interfaces/store.ts
@@ -1,0 +1,10 @@
+export interface ILoginedUser {
+  id: number;
+  username: string;
+  email: string;
+  role: string;
+  status: boolean;
+  profile: string;
+  annual_limit: number;
+  annual_count: number;
+}

--- a/src/interfaces/store.ts
+++ b/src/interfaces/store.ts
@@ -2,9 +2,8 @@ export interface ILoginedUser {
   id: number;
   username: string;
   email: string;
-  role: string;
-  status: boolean;
+  role: 'ROLE_USER' | 'ROLE_ADMIN' | 'ROLE_MASTER';
   profile: string;
-  annual_limit: number;
-  annual_count: number;
+  remainDays: number;
+  hire_date: string;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
-import { worker } from './mocks/broswer';
+// import { worker } from './mocks/broswer';
 
-if (process.env.NODE_ENV === 'development') {
-  worker.start();
-}
+// if (process.env.NODE_ENV === 'development') {
+//   worker.start();
+// }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import { createLogger } from 'redux-logger';
-
+import loginedUserReducer from './reducers/userReducers';
 const logger = createLogger();
 
-const rootReducer = combineReducers({});
+const rootReducer = combineReducers({
+  loginedUser: loginedUserReducer
+});
 
 const store = configureStore({
   reducer: rootReducer,

--- a/src/store/reducers/userReducers.ts
+++ b/src/store/reducers/userReducers.ts
@@ -1,0 +1,18 @@
+import { createAction, createReducer } from '@reduxjs/toolkit';
+import { ILoginedUser } from '../../interfaces/store';
+
+export const login = createAction('loginedUser/login');
+
+const loginedUser = createReducer(
+  {},
+  {
+    [login]: (state: ILoginedUser, action) => {
+      return {
+        ...state,
+        ...action.payload
+      };
+    }
+  }
+);
+
+export default loginedUser;

--- a/src/store/reducers/userReducers.ts
+++ b/src/store/reducers/userReducers.ts
@@ -4,7 +4,15 @@ import { ILoginedUser } from '../../interfaces/store';
 export const login = createAction('loginedUser/login');
 
 const loginedUser = createReducer(
-  {},
+  {
+    id: 1,
+    username: '김테슽',
+    email: 'user@example.com',
+    role: 'USER',
+    profile: 'https://lupinbucket.s3.ap-northeast-2.amazonaws.com/person.png',
+    remainDays: 2,
+    hire_date: '2023-04-27'
+  },
   {
     [login]: (state: ILoginedUser, action) => {
       return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,6 +2942,16 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+sweetalert2-react-content@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/sweetalert2-react-content/-/sweetalert2-react-content-5.0.7.tgz#6fd7299978b2e0221d3049746ff2b39c1a7aa72d"
+  integrity sha512-8Fk82Mpk45lFXpJWKIFF/lq8k/dJKDDQGFcuqVosaL/qRdViyAs5+u37LoTGfnOIvf+rfQB3PAXcp1XLLn+0ew==
+
+sweetalert2@^11.7.5:
+  version "11.7.5"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.7.5.tgz#d905b792cfcb69d5db479f839151ce12d8804a8e"
+  integrity sha512-RBPKdK8Uf9/bz9r4vy7x6sGqf0MioSXt1po1lAwwcl3AwbjHVTc5S0yud4ZJKU1EhvJFVDrFoqIpHwWERwZJEA==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
- 알림창 구현 위한 라이브러리 설치 (sweetalert2)
- useGetSchedules 훅 서버와 연결
- 변경된 요구사항에 따라 api 요청 시 해당 년-월 전달하도록 세팅
- 캘린더의 이전 달 / 다음 달 버튼 클릭 시 그에 맞게 api 요청
- 로그인한 유저의 데이터를 저장할 store 코드 작성

[참고 사항]
- 현재 캘린더의 이전 / 다음 버튼 클릭 시 api 요청은 해당 년-월에 맞게 잘 가지만 캘린더 렌더링이 제대로 되지 않는 문제 발생
- 아직 로그인 화면이 구현되지 않아 store의 state를 임의로 세팅
- store의 initialState는 빈 객체로 수정하시고, 로그인이 되면 store의 state가 업데이트 되는 로직을 작성해주세요!